### PR TITLE
quote_plus to quote

### DIFF
--- a/discogs_client.py
+++ b/discogs_client.py
@@ -45,7 +45,7 @@ class APIBase(object):
 
     @property
     def _uri(self):
-        return '%s/%s/%s' % (api_uri, self._uri_name, urllib.quote_plus(unicode(self._id).encode('utf-8')))
+        return '%s/%s/%s' % (api_uri, self._uri_name, urllib.quote(unicode(self._id).encode('utf-8')))
 
     @property
     def data(self):


### PR DESCRIPTION
it looks like something was going wrong with plus-quoting urls and the requests module. 

When I tried to do `discogs.Artist('Crystal Castles').data` it was getting a 404. So I tried manually using `requests.get()`:

```
>>> requests.get('http://api.discogs.com/artist/Karate')
<Response [200]>
>>> requests.get('http://api.discogs.com/artist/Crystal+Castles')
<Response [404]>
>>> requests.get('http://api.discogs.com/artist/Crystal Castles')
<Response [200]>
```

After I changed it to `urllib.quote` instead of `urllib.quote_plus`, "Crystal Castles" and "!!!" both worked fine using the normal `discogs.Artist()`.
