### PR TITLE
anv result failure

### DIFF
--- a/discogs_client.py
+++ b/discogs_client.py
@@ -292,7 +292,7 @@ class Search(APIBase):
         id = result['title']
         if result['type'] in ('master', 'release'):
             id = result['uri'].split('/')[-1]
-        elif result['type'] == 'artist':
+        elif result['type'] == 'anv':
             return Artist(id, anv=result.get('anv'))
         return _class_from_string(result['type'])(id)
 


### PR DESCRIPTION
In Search._to_object, the special case of a result matching an artist name variation was determined by testing the result type for equality to "artist" instead of "anv". This resulted in "anv" type results to be read from the class_map dict, which doesn't contain the key "anv".
