### PR TITLE
small fix for quote vs quote_plus

### DIFF
--- a/discogs_client.py
+++ b/discogs_client.py
@@ -78,7 +78,7 @@ class APIBase(object):
 
     @property
     def _uri(self):
-        return '%s/%s/%s' % (api_uri, self._uri_name, urllib.quote(unicode(self._id).encode('utf-8')))
+        return '%s/%s/%s' % (api_uri, self._uri_name, urllib.quote_plus(unicode(self._id).encode('utf-8')))
 
     @property
     def data(self):


### PR DESCRIPTION
The upstream requests library has caused a few issues over the last month. Namely URL escaping of special characters.

This is now fixed. I believe requests lib 10.1 -> 10.3 should be considered "broken"
See 
https://github.com/kennethreitz/requests/issues/404
https://github.com/kennethreitz/requests/issues/437

This pull requests includes a very small change to the way the client encodes urls. Substituting quote() for quote_plus() (discogs uses the + for slugs)

See

http://docs.python.org/library/urllib.html#urllib.quote

"Like quote(), but also replaces spaces by plus signs, as required for quoting HTML form values when building up a query string to go into a URL. Plus signs in the original string are escaped unless they are included in safe. It also does not have safe default to '/' "
