### PR TITLE
Detailed exceptions for token request failures

### DIFF
--- a/discogs_client/client.py
+++ b/discogs_client/client.py
@@ -10,7 +10,7 @@ except ImportError:
     from urllib.parse import urlencode
 
 from discogs_client import models
-from discogs_client.exceptions import ConfigurationError, HTTPError
+from discogs_client.exceptions import ConfigurationError, HTTPError, AuthorizationError
 from discogs_client.utils import update_qs
 from discogs_client.fetchers import RequestsFetcher, OAuth2Fetcher
 
@@ -58,7 +58,7 @@ class Client(object):
 
         content, status_code = self._fetcher.fetch(self, 'POST', self._request_token_url, data=postdata, headers=params)
         if status_code != 200:
-            raise HTTPError('Invalid response from request token URL.', status_code)
+            raise AuthorizationError('Could not get request token.', status_code, content)
 
         token, secret = self._fetcher.store_token_from_qs(content)
 

--- a/discogs_client/exceptions.py
+++ b/discogs_client/exceptions.py
@@ -29,4 +29,4 @@ class AuthorizationError(HTTPError):
     """The server rejected the client's credentials."""
     def __init__(self, message, code, response):
         super(AuthorizationError, self).__init__(message, code)
-        self.msg = '%s Response: %s' % (self.msg, repr(response))
+        self.msg = '{0} Response: {1!r}'.format(self.msg, response)

--- a/discogs_client/exceptions.py
+++ b/discogs_client/exceptions.py
@@ -23,3 +23,10 @@ class HTTPError(DiscogsAPIError):
 
     def __str__(self):
         return self.msg
+
+
+class AuthorizationError(HTTPError):
+    """The server rejected the client's credentials."""
+    def __init__(self, message, code, response):
+        super(AuthorizationError, self).__init__(message, code)
+        self.msg = '%s Response: %s' % (self.msg, repr(response))


### PR DESCRIPTION
This adds richer exception information when the request token request fails. This is important because it can fail for several different reasons, including:

* bad timestamp
* bad consumer
* bad signature

This makes it at least possible to tell what's going wrong.

Before:

    $ python -c "import discogs_client ; discogs_client.Client('[...]', '[...]', '[...]').get_authorize_url()"
    [...]
    discogs_client.exceptions.HTTPError: 401: Invalid response from request token URL.

After:

    $ python -c "import discogs_client ; discogs_client.Client('[...]', '[...]', '[...]').get_authorize_url()"
    [...]
    discogs_client.exceptions.AuthorizationError: 401: Could not get request token. Response: 'Invalid consumer.'

This came up in https://github.com/sampsyo/beets/issues/1417.