### PR TITLE
Update authorize URL to use HTTPS

### DIFF
--- a/discogs_client/client.py
+++ b/discogs_client/client.py
@@ -18,7 +18,7 @@ from discogs_client.fetchers import RequestsFetcher, OAuth2Fetcher
 class Client(object):
     _base_url = 'https://api.discogs.com'
     _request_token_url = 'https://api.discogs.com/oauth/request_token'
-    _authorize_url = 'http://www.discogs.com/oauth/authorize'
+    _authorize_url = 'https://www.discogs.com/oauth/authorize'
     _access_token_url = 'https://api.discogs.com/oauth/access_token'
 
     def __init__(self, user_agent, consumer_key=None, consumer_secret=None, token=None, secret=None):


### PR DESCRIPTION
This endpoint now supports HTTPS (although doesn't require it). 