### PR TITLE
Save an extra fetch by storing the data fetched for page 1

### DIFF
--- a/discogs_client/models.py
+++ b/discogs_client/models.py
@@ -291,6 +291,9 @@ class BasePaginatedResponse(object):
 
     def _load_pagination_info(self):
         data = self.client._get(self._url_for_page(1))
+        self._pages[1] = [
+                self._transform(item) for item in data[self._list_key]
+            ]
         self._num_pages = data['pagination']['pages']
         self._num_items = data['pagination']['items']
 

--- a/discogs_client/models.py
+++ b/discogs_client/models.py
@@ -292,8 +292,8 @@ class BasePaginatedResponse(object):
     def _load_pagination_info(self):
         data = self.client._get(self._url_for_page(1))
         self._pages[1] = [
-                self._transform(item) for item in data[self._list_key]
-            ]
+            self._transform(item) for item in data[self._list_key]
+        ]
         self._num_pages = data['pagination']['pages']
         self._num_items = data['pagination']['items']
 


### PR DESCRIPTION
Small change to pagination mechanism - when loading pagination info, data for page 1 is loaded but currently not stored. When asking for page 1, the data is loaded - again. Example script:

```python
import discogs_client
d = discogs_client.Client('ExampleApplication/0.1')
d.verbose = True

a = d.artist(251558)
print "Iterating over releases..."
for r in a.releases:
    pass
```

Output without this change shows an extra fetch:
Iterating over releases...
GET https://api.discogs.com/artists/251558
GET https://api.discogs.com/artists/251558/releases?per_page=50&page=1
GET https://api.discogs.com/artists/251558/releases?per_page=50&page=1
GET https://api.discogs.com/artists/251558/releases?per_page=50&page=2
...

After the fix, page 1 is no longer loaded twice:
Iterating over releases...
GET https://api.discogs.com/artists/251558
GET https://api.discogs.com/artists/251558/releases?per_page=50&page=1
GET https://api.discogs.com/artists/251558/releases?per_page=50&page=2
...
