### PR TITLE
Search utf8 strings

### DIFF
--- a/discogs_client/client.py
+++ b/discogs_client/client.py
@@ -141,8 +141,14 @@ class Client(object):
         function are serialized into the request's query string.
         """
         if query:
-            fields['q'] = ' '.join(query)
-
+            unicode_query = []
+            for q in query:
+                try:
+                    unicode_q = q.decode('utf8')
+                except (UnicodeDecodeError, UnicodeEncodeError, AttributeError):
+                    unicode_q = q
+                unicode_query.append(unicode_q)
+            fields['q'] = ' '.join(unicode_query)
         return models.MixedPaginatedList(
             self,
             update_qs(self._base_url + '/database/search', fields),

--- a/discogs_client/tests/test_models.py
+++ b/discogs_client/tests/test_models.py
@@ -34,6 +34,13 @@ class ModelsTestCase(DiscogsClientTestCase):
         self.assertTrue(isinstance(results[0], Artist))
         self.assertTrue(isinstance(results[1], Release))
 
+    def test_utf8_search(self):
+        uni_string = 'caf\xe9'.encode('utf8')
+        try:
+            results = self.d.search(uni_string)
+        except Exception as e:
+            self.fail('exception {} was raised'.format(e))
+
     def test_fee(self):
         fee = self.d.fee_for(20.5, currency='EUR')
         self.assertEqual(fee.currency, 'USD')


### PR DESCRIPTION
Now you can search using utf-8 encoded strings.
This converts all strings in the query array to unicode so that they can be joined.

To test:
1. All tests should pass.
2. you can also search using utf-8 characters.
[Fixes #102919040]