### PR TITLE
Adjust name to reflect oauth version

### DIFF
--- a/discogs_client/client.py
+++ b/discogs_client/client.py
@@ -12,7 +12,7 @@ except ImportError:
 from discogs_client import models
 from discogs_client.exceptions import ConfigurationError, HTTPError, AuthorizationError
 from discogs_client.utils import update_qs
-from discogs_client.fetchers import RequestsFetcher, OAuth2Fetcher, UserTokenRequestsFetcher
+from discogs_client.fetchers import RequestsFetcher, OAuth1Fetcher, UserTokenRequestsFetcher
 
 
 class Client(object):
@@ -35,7 +35,7 @@ class Client(object):
             self._fetcher = UserTokenRequestsFetcher(user_token)
 
     def set_consumer_key(self, consumer_key, consumer_secret):
-        self._fetcher = OAuth2Fetcher(consumer_key, consumer_secret)
+        self._fetcher = OAuth1Fetcher(consumer_key, consumer_secret)
 
     def set_token(self, token, secret):
         try:

--- a/discogs_client/fetchers.py
+++ b/discogs_client/fetchers.py
@@ -64,7 +64,7 @@ class UserTokenRequestsFetcher(Fetcher):
         return resp.content, resp.status_code
 
 
-class OAuth2Fetcher(Fetcher):
+class OAuth1Fetcher(Fetcher):
     """Fetches via HTTP + OAuth 1.0a from the Discogs API."""
     def __init__(self, consumer_key, consumer_secret, token=None, secret=None):
         self.client = oauth1.Client(consumer_key, client_secret=consumer_secret)


### PR DESCRIPTION
I was looking to integrate one of my applications with discogs's api.  Upon reviewing the client code I saw 'Oauth2Fetcher' and assumed that [oauth 2.0 ](http://oauthbible.com/#oauth-10a-three-legged) was being used.   After reading a summary of the spec I believe that this client is using [oauth 1.0a](http://oauthbible.com/#oauth-10a-three-legged) due to it's use of `oauth_verifier`.

In addition, Oauth 1.0a is mentioned in the code comments:
```
class OAuth2Fetcher(Fetcher):
        """Fetches via HTTP + OAuth 1.0a from the Discogs API."""
        def __init__(self, consumer_key, consumer_secret, token=None, secret=None):
            self.client = oauth1.Client(consumer_key, client_secret=consumer_secret)
            self.store_token(token, secret)
```
