### PR TITLE
Fixes #82 - Exposes X-Discogs-Ratelimit-Remaining header

### DIFF
--- a/discogs_client/fetchers.py
+++ b/discogs_client/fetchers.py
@@ -50,6 +50,8 @@ class RequestsFetcher(Fetcher):
     """Fetches via HTTP from the Discogs API."""
     def fetch(self, client, method, url, data=None, headers=None, json=True):
         resp = requests.request(method, url, data=data, headers=headers)
+        self.rate_limit_remaining = resp.headers.get(
+                'X-Discogs-Rate-Limit-Remaining')
         return resp.content, resp.status_code
 
 
@@ -61,6 +63,8 @@ class UserTokenRequestsFetcher(Fetcher):
     def fetch(self, client, method, url, data=None, headers=None, json=True):
         resp = requests.request(method, url, params={'token':self.user_token},
                                 data=data, headers=headers)
+        self.rate_limit_remaining = resp.headers.get(
+                'X-Discogs-Ratelimit-Remaining')
         return resp.content, resp.status_code
 
 
@@ -93,6 +97,8 @@ class OAuth2Fetcher(Fetcher):
                                               body=data, headers=headers)
 
         resp = request(method, uri, headers=headers, data=body)
+        self.rate_limit_remaining = resp.headers.get(
+                'X-Discogs-Rate-Limit-Remaining')
         return resp.content, resp.status_code
 
 


### PR DESCRIPTION
I don't really think it should be the job of the client to limit the request rate, since the API actually does this already. But, it is worth exposing the remaining requests. If this means we should open another issue I am happy to do so.

I could expose the other ratelimit headers easily if this is preferable. 

Also, I chose to only add the attribute after a request has been made, rather than add it to the base fetcher class with statically coded value like None or 60 I felt it's better to let the api handle that.

Thanks for your time!