### PR TITLE
Implement exponential backoff

### DIFF
--- a/discogs_client/client.py
+++ b/discogs_client/client.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import backoff
 import warnings
 import json
 try:
@@ -93,6 +94,7 @@ class Client(object):
         if not self.user_agent:
             raise ConfigurationError('Invalid or no User-Agent set.')
 
+    @backoff.on_exception(backoff.expo, HTTPError)
     def _request(self, method, url, data=None):
         if self.verbose:
             print(' '.join((method, url)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ docopt==0.6.1
 requests==2.20.0
 oauthlib==0.7.2
 sh==1.08
+backoff=1.10.0


### PR DESCRIPTION
This fork makes use of the [`backoff`](https://pypi.org/project/backoff/) library to fail gracefully when a rate limit is reached. Instead of raising an exception to the client, the library automatically retries failed requests using an [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) strategy.