### PR TITLE
Adding `catno` entry support in Label model.

### DIFF
--- a/discogs_client/models.py
+++ b/discogs_client/models.py
@@ -522,6 +522,7 @@ class Label(PrimaryAPIObject):
     id = SimpleField()
     name = SimpleField()
     profile = SimpleField()
+    catno = SimpleField()
     urls = SimpleField()
     images = SimpleField()
     contact_info = SimpleField()

--- a/discogs_client/tests/test_models.py
+++ b/discogs_client/tests/test_models.py
@@ -17,6 +17,13 @@ class ModelsTestCase(DiscogsClientTestCase):
         r = self.d.release(1)
         self.assertEqual(r.title, 'Stockholm')
 
+    def test_labels(self):
+        """Labels can be fetched and parsed"""
+        r = self.d.release(1)
+        l = r.labels[0]
+        self.assertEqual(l.name, "Svek")
+        self.assertEqual(l.catno, "SK032")
+
     def test_master(self):
         """Masters can be fetched and parsed"""
         m = self.d.master(4242)


### PR DESCRIPTION
#### Changes in this PR:
- Added new entry in Label() model
- Added associated unit test

##### Motivations
While working on a music search engine, I needed to have the `catno` fied in order to have a more consistent request through others services and to avoid involving scrapping.

Regards